### PR TITLE
feat: main page 페이지네이션, 검색 기능 훅 추가

### DIFF
--- a/app/main/core/companiesFetchHook.tsx
+++ b/app/main/core/companiesFetchHook.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useCallback, useState } from "react";
+import { getCompanyListAPI } from "./companyListAPI";
+import {
+  CompanyListQuery,
+  CompanyListResponse,
+  CompanyDTO,
+} from "@/global/types/data-contracts";
+
+interface UseItemsFetchOutput {
+  isLoading: boolean;
+  companies: CompanyDTO[];
+  totalPages: number;
+}
+
+export const useCompanyListFetch = (
+  params: CompanyListQuery
+): UseItemsFetchOutput => {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [data, setData] = useState<CompanyListResponse>({
+    companies: [],
+    page: 1,
+    totalPages: 1,
+  });
+
+  const fetchItems = useCallback(async (): Promise<void> => {
+    try {
+      setIsLoading(true);
+      const startTime = Date.now();
+
+      console.log("쿼리 파라미터: ", params);
+      const response: CompanyListResponse = await getCompanyListAPI(params);
+      setData({
+        companies: response.companies,
+        page: response.page,
+        totalPages: response.totalPages,
+      });
+
+      // 경과시간 계산
+      const elTime: number = Date.now() - startTime;
+      const remainingTime: number = Math.max(500 - elTime, 0);
+
+      // 최소 시간 지연(스켈레톤 보여주는 로딩 최소 시간)
+      await new Promise((resolve) => setTimeout(resolve, remainingTime));
+    } catch (error) {
+      console.error("지원 내역 불러오기 오류: ", error);
+    } finally {
+      setIsLoading(false); //API실행이 종료되면 섹션 로딩 상태 종료
+    }
+  }, [params]);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  return {
+    isLoading,
+    companies: data.companies,
+    totalPages: data.totalPages,
+  };
+};

--- a/app/main/core/companyListAPI.ts
+++ b/app/main/core/companyListAPI.ts
@@ -1,0 +1,33 @@
+import { AxiosResponse } from "axios";
+import { instance } from "@/global/utils/axiosInstance";
+import {
+  CompanyListResponse,
+  CompanyListQuery,
+} from "@/global/types/data-contracts";
+
+/** 전체 기업 조회
+ * @param {Object} params - 쿼리 정보
+ * @param {int} params.page - 페이지 번호
+ * @param {int} params.keyword - 검색 키워드
+ * @param {int} params.filter - 필터
+ */
+export const getCompanyListAPI = async (
+  params: Partial<CompanyListQuery> = {}
+): Promise<CompanyListResponse> => {
+  //쿼리 기본값
+  const { page = 1, keyword = "", filter = "revenueDesc" } = params;
+
+  //FIXME: 지금 엔드포인트는 세정님이 만드신 api로 연결되는데, 재완님한테 검색키워드랑 필터, 페이지 쿼리 받아서 카테고리도 추가 + 지원자수도 계산하고  totalpages, page까지 같이 반환해주는걸로 api짜달라고 하기
+  try {
+    const response: AxiosResponse<CompanyListResponse> = await instance.get(
+      "/api/companies",
+      {
+        params: { page, keyword, filter },
+      }
+    );
+    console.log("getCompanyListAPI: ", response.data);
+    return response.data;
+  } catch (err) {
+    throw err;
+  }
+};

--- a/app/main/features/companyList/components/CompanyItems.tsx
+++ b/app/main/features/companyList/components/CompanyItems.tsx
@@ -29,7 +29,7 @@ export function CompanyItems({ ranking, itemData }: CompanyItemsProps) {
       <Box sx={labelOrderBoxStyle}>
         <Typo
           className="text_R_14"
-          content={`${ranking + 1}위`}
+          content={`${ranking}위`}
           color={colorChips.gray_100}
           customStyle={{ textAlign: "center" }}
         />

--- a/app/main/features/companyList/components/CompanyItems.tsx
+++ b/app/main/features/companyList/components/CompanyItems.tsx
@@ -82,7 +82,7 @@ export function CompanyItems({ ranking, itemData }: CompanyItemsProps) {
       <Box sx={labelDataBoxStyle}>
         <Typo
           className="text_R_14"
-          content={itemData.employeeCnt.toString()}
+          content={`${itemData.employeeCnt}명`}
           color={colorChips.gray_100}
           customStyle={{ textAlign: "center" }}
         />
@@ -90,7 +90,7 @@ export function CompanyItems({ ranking, itemData }: CompanyItemsProps) {
       <Box sx={labelDataBoxStyle}>
         <Typo
           className="text_R_14"
-          content={itemData.applicantCnt.toString()}
+          content={`${itemData.applicantCnt}명`}
           color={colorChips.gray_100}
           customStyle={{ textAlign: "center" }}
         />

--- a/app/main/features/companyList/feature.tsx
+++ b/app/main/features/companyList/feature.tsx
@@ -1,36 +1,22 @@
 import { Stack } from "@mui/material";
 import { companyListWrapperStyle } from "@/global/styles/companyListStyles";
 import { CompanyItems } from "./components/CompanyItems";
+import { CompanyDTO } from "@/global/types/data-contracts";
 
-const mockData = [
-  {
-    name: "코드잇",
-    image:
-      "https://s3-alpha-sig.figma.com/img/14ea/2072/7d797dc61be213072dfdfe95dc9d2494?Expires=1739145600&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=NDjzJ4~YCVsb5sToJq49pE63fuvnB6MksZU3tEKQhmRkJ3PZ6iOq-XL82aHpZ56F8TZwkzwjwjwGPt6Qe1yH~NEye~NRFF~o3yVNdG0Zg8oBkZAkmOM3oTVmoA5Xh8J-X3~6cTjYSLjNtP3ObTC7d-NwCaeQmkw12r5hH3rOmsVjk~~Crx6yMTqdQZRdSmaIW6e0pPek6U1kTdphUWYbfx2koA7DS02NtHR3oFBfeLqTl4du5gomP2XRk3-CYc8CwFO0VMk0p5f~CX478UzYf2Ogzsasj9~SZxFEt0pmlS3JsfFfrpsUdV-Xt94zKisHvRrkLbdw0r3nKGm5hrMsuA__",
-    content:
-      '코드잇은 온라인 코딩 교육 서비스를 운영하는 EdTech 스타트업입니다. 코딩 교육과 데이터 사이언스 교육에 대한 수요는 급격히 늘어나고 있지만, 아직까지 좋은 교육 서비스를 찾기란 쉽지 않습니다. 이를 해결하고자 코드잇은 모든 강의를 자체 제작하여 퀄리티 높은 콘텐츠를 제공하고, 동시에 코딩 교육에 최적화된 플랫폼을 개발하고 있습니다. 모든 강의를 마음껏 들을 수 있는 "코드잇 무제한 멤버십"을 제공하고 있으며, 지난 5년 동안 21만 명의 수강생과 평균 만족도 4.9점이라는 국내 교육 업계에서 보기 드문 성과를 달성하였습니다. 또한 콘텐츠와 기술력을 인정받아 2021년 10월 Series B 투자를 받아 누적 140억 원의 투자를 받았고, 현재 40여 명의 팀원이 같은 목표를 향해 나아가고 있습니다.',
-    category: [{ id: "wer", category: "에듀테크" }],
-    salesRevenue: "14000000000",
-    employeeCnt: 50,
-    applicantCnt: 12,
-  },
-  {
-    name: "뤼이드",
-    image: "/#fdsa",
-    content:
-      '뤼이드는 온라인 코딩 교육 서비스를 운영하는 EdTech 스타트업입니다. 코딩 교육과 데이터 사이언스 교육에 대한 수요는 급격히 늘어나고 있지만, 아직까지 좋은 교육 서비스를 찾기란 쉽지 않습니다. 이를 해결하고자 코드잇은 모든 강의를 자체 제작하여 퀄리티 높은 콘텐츠를 제공하고, 동시에 코딩 교육에 최적화된 플랫폼을 개발하고 있습니다. 모든 강의를 마음껏 들을 수 있는 "코드잇 무제한 멤버십"을 제공하고 있으며, 지난 5년 동안 21만 명의 수강생과 평균 만족도 4.9점이라는 국내 교육 업계에서 보기 드문 성과를 달성하였습니다. 또한 콘텐츠와 기술력을 인정받아 2021년 10월 Series B 투자를 받아 누적 140억 원의 투자를 받았고, 현재 40여 명의 팀원이 같은 목표를 향해 나아가고 있습니다.',
-    category: [{ id: "wer", category: "에듀테크" }],
-    salesRevenue: "350000000",
-    employeeCnt: 12,
-    applicantCnt: 6,
-  },
-];
+interface CompanyListProps {
+  companies: CompanyDTO[];
+  page: number | undefined;
+}
 
-export default function CompanyList() {
+export default function CompanyList({ companies, page = 1 }: CompanyListProps) {
   return (
     <Stack sx={companyListWrapperStyle}>
-      {mockData.map((item, idx) => (
-        <CompanyItems key={idx} ranking={idx} itemData={item} />
+      {companies.map((item, idx) => (
+        <CompanyItems
+          key={idx}
+          ranking={(page - 1) * 10 + idx + 1}
+          itemData={item}
+        />
       ))}
     </Stack>
   );

--- a/app/main/features/index.tsx
+++ b/app/main/features/index.tsx
@@ -1,9 +1,7 @@
 import CompanyList from "./companyList/feature";
-import ListPagination from "./listPagination/feature";
 import ListTitle from "./listTitle/feature";
 
 export const Features = {
   ListTitle,
   CompanyList,
-  ListPagination,
 };

--- a/app/main/features/listTitle/feature.tsx
+++ b/app/main/features/listTitle/feature.tsx
@@ -4,7 +4,27 @@ import { Typo } from "@/global/styles/Typo";
 import { Box, Stack } from "@mui/material";
 import React from "react";
 
-export default function ListTitle(): React.ReactElement {
+interface ListTitleProps {
+  onSearch: (keyword: string) => void;
+}
+
+export default function ListTitle({
+  onSearch,
+}: ListTitleProps): React.ReactElement {
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>): void => {
+    const value = e.target.value.trim();
+    onSearch(value);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    const target = e.currentTarget;
+
+    if (e.key === "Enter") {
+      const value = target.value.trim();
+      onSearch(value);
+    }
+  };
+
   return (
     <Stack sx={listHeaderContainerStyle}>
       <Typo
@@ -15,9 +35,10 @@ export default function ListTitle(): React.ReactElement {
       <Stack sx={utilsContainerSytle}>
         <Box sx={searchBoxStyle}>
           <SearchInput
-            width="100%"
             variation="left"
             placeholder="검색어를 입력해주세요"
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
           />
         </Box>
         <Box sx={sortBoxStyle}>

--- a/app/main/features/listTitle/feature.tsx
+++ b/app/main/features/listTitle/feature.tsx
@@ -1,3 +1,4 @@
+import { SearchInput } from "@/global/components/input/SearchInput";
 import { colorChips } from "@/global/styles/colorChips";
 import { Typo } from "@/global/styles/Typo";
 import { Box, Stack } from "@mui/material";
@@ -13,10 +14,10 @@ export default function ListTitle(): React.ReactElement {
       />
       <Stack sx={utilsContainerSytle}>
         <Box sx={searchBoxStyle}>
-          <Typo
-            className="text_SB_20"
-            content="검색"
-            color={colorChips.white}
+          <SearchInput
+            width="100%"
+            variation="left"
+            placeholder="검색어를 입력해주세요"
           />
         </Box>
         <Box sx={sortBoxStyle}>
@@ -53,7 +54,6 @@ const searchBoxStyle = {
   alignItems: "center",
   width: ["189px", "269px", "448px"],
   height: ["40px", "48px"],
-  border: `1px solid ${colorChips.white}`, //border는 컴포넌트 넣고 삭제
 };
 
 const sortBoxStyle = {

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -1,26 +1,96 @@
+"use client";
+
 import { Box, Stack } from "@mui/material";
 import { Features } from "./features";
 import { Single } from "./single";
-// import { SkeletonCompanyList } from "@/global/components/SkeletonCompanyItems";
+import { SkeletonCompanyList } from "@/global/components/SkeletonCompanyItems";
+import { ListPagination } from "@/global/components/ListPagination";
+import { useCallback, useState } from "react";
+import { CompanyListQuery } from "@/global/types/data-contracts";
+import { useCompanyListFetch } from "./core/companiesFetchHook";
 import {
   listLayout,
   listWrapperStyle,
   scrollWrapper,
 } from "@/global/styles/companyListStyles";
 
+//TODO: 백엔드 api 불러와서 목데이터랑 totalPages 지우기
+const totalPages = 5;
+
+const companies = [
+  {
+    id: "22",
+    idx: "22",
+    name: "코드잇",
+    image:
+      "https://s3-alpha-sig.figma.com/img/14ea/2072/7d797dc61be213072dfdfe95dc9d2494?Expires=1739145600&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=NDjzJ4~YCVsb5sToJq49pE63fuvnB6MksZU3tEKQhmRkJ3PZ6iOq-XL82aHpZ56F8TZwkzwjwjwGPt6Qe1yH~NEye~NRFF~o3yVNdG0Zg8oBkZAkmOM3oTVmoA5Xh8J-X3~6cTjYSLjNtP3ObTC7d-NwCaeQmkw12r5hH3rOmsVjk~~Crx6yMTqdQZRdSmaIW6e0pPek6U1kTdphUWYbfx2koA7DS02NtHR3oFBfeLqTl4du5gomP2XRk3-CYc8CwFO0VMk0p5f~CX478UzYf2Ogzsasj9~SZxFEt0pmlS3JsfFfrpsUdV-Xt94zKisHvRrkLbdw0r3nKGm5hrMsuA__",
+    content:
+      '코드잇은 온라인 코딩 교육 서비스를 운영하는 EdTech 스타트업입니다. 코딩 교육과 데이터 사이언스 교육에 대한 수요는 급격히 늘어나고 있지만, 아직까지 좋은 교육 서비스를 찾기란 쉽지 않습니다. 이를 해결하고자 코드잇은 모든 강의를 자체 제작하여 퀄리티 높은 콘텐츠를 제공하고, 동시에 코딩 교육에 최적화된 플랫폼을 개발하고 있습니다. 모든 강의를 마음껏 들을 수 있는 "코드잇 무제한 멤버십"을 제공하고 있으며, 지난 5년 동안 21만 명의 수강생과 평균 만족도 4.9점이라는 국내 교육 업계에서 보기 드문 성과를 달성하였습니다. 또한 콘텐츠와 기술력을 인정받아 2021년 10월 Series B 투자를 받아 누적 140억 원의 투자를 받았고, 현재 40여 명의 팀원이 같은 목표를 향해 나아가고 있습니다.',
+    category: [{ id: "wer", category: "에듀테크" }],
+    salesRevenue: "14000000000",
+    employeeCnt: 50,
+    applicantCnt: 12,
+    createdAt: "2025-02-14",
+    updatedAt: "2025-02-15",
+  },
+  {
+    id: "22",
+    idx: "22",
+    name: "뤼이드",
+    image: "/#fdsa",
+    content:
+      '뤼이드는 온라인 코딩 교육 서비스를 운영하는 EdTech 스타트업입니다. 코딩 교육과 데이터 사이언스 교육에 대한 수요는 급격히 늘어나고 있지만, 아직까지 좋은 교육 서비스를 찾기란 쉽지 않습니다. 이를 해결하고자 코드잇은 모든 강의를 자체 제작하여 퀄리티 높은 콘텐츠를 제공하고, 동시에 코딩 교육에 최적화된 플랫폼을 개발하고 있습니다. 모든 강의를 마음껏 들을 수 있는 "코드잇 무제한 멤버십"을 제공하고 있으며, 지난 5년 동안 21만 명의 수강생과 평균 만족도 4.9점이라는 국내 교육 업계에서 보기 드문 성과를 달성하였습니다. 또한 콘텐츠와 기술력을 인정받아 2021년 10월 Series B 투자를 받아 누적 140억 원의 투자를 받았고, 현재 40여 명의 팀원이 같은 목표를 향해 나아가고 있습니다.',
+    category: [{ id: "wer", category: "에듀테크" }],
+    salesRevenue: "350000000",
+    employeeCnt: 12,
+    applicantCnt: 6,
+    createdAt: "2025-02-14",
+    updatedAt: "2025-02-15",
+  },
+];
+
 export default function Main() {
+  const [params, setParams] = useState<CompanyListQuery>({
+    page: 1, //기본 1페이지
+    keyword: "",
+    filter: "revenueDesc", //기본 정렬 기준: 매출액 높은 순
+  });
+
+  /**
+   * 파라미터 업데이트
+   * @description 기존의 파라미터 복사, 새로운 파라미터를 기존 상태에 추가(덮어씌우기)
+   */
+  const updateParams = useCallback((newParams: CompanyListQuery): void => {
+    setParams((prev) => ({ ...prev, ...newParams }));
+  }, []);
+
+  console.log("params 업데이트 테스트: ", params);
+
+  //api호출
+  // const { companies, totalPages, isLoading } = useCompanyListFetch(params);
+
+  // const isShowSkeleton = isLoading || !companies.length;
+
   return (
     <Stack sx={listLayout}>
-      <Features.ListTitle />
+      <Features.ListTitle onSearch={(keyword) => updateParams({ keyword })} />
 
       <Box sx={scrollWrapper}>
         <Box sx={listWrapperStyle}>
           <Single.ListLabel />
-          <Features.CompanyList />
+          {/* {isShowSkeleton ? (
+            <SkeletonCompanyList />
+          ) : ( */}
+          <Features.CompanyList companies={companies} page={params.page} />
+          {/* )} */}
         </Box>
       </Box>
 
-      <Features.ListPagination />
+      <ListPagination
+        page={params.page ?? 1}
+        count={totalPages}
+        onPageChange={(page) => updateParams({ page })}
+      />
     </Stack>
   );
 }

--- a/app/my-applications/core/applicationListAPI.ts
+++ b/app/my-applications/core/applicationListAPI.ts
@@ -5,7 +5,7 @@ import {
   ApplicationListQuery,
 } from "@/global/types/data-contracts";
 
-/** 상품 목록 조회
+/** 지원 내역 조회
  * @param {Object} params - 쿼리 정보
  * @param {int} params.page - 페이지 번호
  * @param {int} params.filter - 지원 상태 필터

--- a/app/my-applications/features/companyList/components/CompanyItems.tsx
+++ b/app/my-applications/features/companyList/components/CompanyItems.tsx
@@ -112,7 +112,7 @@ export function CompanyItems({ order, itemData }: CompanyItemsProps) {
       <Box sx={labelDataBoxStyle}>
         <Typo
           className="text_R_14"
-          content={`${itemData.applicantCnt.toString()} 명`}
+          content={`${itemData.applicantCnt.toString()}명`}
           color={colorChips.gray_100}
           customStyle={{ textAlign: "center" }}
         />

--- a/app/my-applications/features/index.tsx
+++ b/app/my-applications/features/index.tsx
@@ -1,9 +1,7 @@
 import CompanyList from "./companyList/feature";
-import ListPagination from "./listPagination/feature";
 import ListTitle from "./listTitle/feature";
 
 export const Features = {
   ListTitle,
   CompanyList,
-  ListPagination,
 };

--- a/app/my-applications/page.tsx
+++ b/app/my-applications/page.tsx
@@ -6,6 +6,7 @@ import { Box, Stack } from "@mui/material";
 import { Features } from "./features";
 import { Single } from "./single";
 import { SkeletonCompanyList } from "@/global/components/SkeletonCompanyItems";
+import { ListPagination } from "@/global/components/ListPagination";
 import { useCallback, useState } from "react";
 import { ApplicationListQuery } from "@/global/types/data-contracts";
 import { useApplicationFetch } from "./core/applicationsFetchHook";
@@ -52,7 +53,7 @@ export default function Page() {
         </Box>
       </Box>
 
-      <Features.ListPagination
+      <ListPagination
         page={params.page ?? 1}
         count={totalPages}
         onPageChange={(page) => updateParams({ page })}

--- a/global/components/ListPagination.tsx
+++ b/global/components/ListPagination.tsx
@@ -1,0 +1,39 @@
+import { CustomPagination } from "@/global/components/CustomPagination";
+import { Box } from "@mui/material";
+
+interface CustomPaginationProps {
+  page: number; // 현재 페이지
+  count: number; // 전체 페이지 수
+  onPageChange: (page: number) => void;
+}
+
+export function ListPagination({
+  page = 1,
+  count = 1,
+  onPageChange,
+}: CustomPaginationProps) {
+  const handlePageClick = (
+    event: React.ChangeEvent<unknown>,
+    value: number
+  ): void => {
+    onPageChange(value);
+  };
+
+  return (
+    <Box
+      sx={{
+        margin: "40px auto",
+        width: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <CustomPagination
+        page={page}
+        count={count}
+        handleChange={handlePageClick}
+      />
+    </Box>
+  );
+}

--- a/global/components/input/SearchInput.tsx
+++ b/global/components/input/SearchInput.tsx
@@ -61,7 +61,7 @@ const SearchStyles: SxProps = {
   border: `1px solid ${colorChips.gray_200}`,
   fontFamily: "pretendard",
   color: colorChips.gray_100,
-  fontSize: ["14px", "14px", "13px"],
+  fontSize: ["13px", "14px", "14px"],
   fontStyle: "normal",
   fontWeight: 400,
   lineHeight: "16.71px",

--- a/global/types/data-contracts.ts
+++ b/global/types/data-contracts.ts
@@ -1,5 +1,13 @@
 export interface CompanyDTO {
   /**
+   * 기업 id
+   */
+  id: string;
+  /**
+   * 기업 idx
+   */
+  idx: string;
+  /**
    * 기업 명
    */
   name: string;
@@ -28,6 +36,31 @@ export interface CompanyDTO {
    * 지원자 수
    */
   applicantCnt: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+//FIXME: 백엔드 완성되면 맞게 수정하기
+export type mainCompanyFilter = "revenueDesc" | "revenueAsc";
+
+export interface CompanyListQuery {
+  page?: number;
+  keyword?: string;
+  filter?: mainCompanyFilter;
+}
+
+export interface CompanyListResponse {
+  companies: CompanyDTO[];
+  page: number;
+  totalPages: number;
+}
+
+export interface ApplicationDTO
+  extends Omit<CompanyDTO, "salesRevenue" | "employeeCnt"> {
+  /**
+   * 지원 상태
+   */
+  status: ApplicationStatus | string;
 }
 
 export type ApplicationStatus = "pending" | "accepted" | "rejected";
@@ -35,26 +68,6 @@ export type ApplicationStatus = "pending" | "accepted" | "rejected";
 export interface ApplicationListQuery {
   page?: number;
   filter?: ApplicationStatus | "all";
-}
-
-export interface ApplicationDTO
-  extends Omit<CompanyDTO, "salesRevenue" | "employeeCnt"> {
-  /**
-   * 지원서 id
-   */
-  id: string;
-  /**
-   * 지원 상태
-   */
-  status: ApplicationStatus | string;
-  /**
-   * 지원 날짜
-   */
-  createdAt: string;
-  /**
-   * 지원서 업데이트 날짜
-   */
-  updatedAt: string;
 }
 
 export interface ApplicationListResponse {

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,8 +7,8 @@ const nextConfig: NextConfig = {
       "s3-alpha-sig.figma.com",
       "contents.nextunicorn.kr",
       "imgs.jobkorea.co.kr",
-    ], // figma 이미지 도메인 허용
-    // 또는 더 유연하게:
+    ],
+    unoptimized: true,
   },
   output: "export", // 정적 배포 하기 위해서
 };


### PR DESCRIPTION
**++ 지금 api/companies 요기는 세정님이 사용하고 계셔서 다른 엔드포인트로 연결해주시면 될거같아요!!**

재완님 메인페이지 백엔드 api 짜실 때
data-contracts.ts 파일에서 companyDTO, CompanyListQuery, CompanyListResponse 얘네 참고해서 타입이랑 변수 이름 일치하게 만들어주시면 좋을것같아요. 필터 이름은 아직 어떻게 만드실지 몰라서 일단 임의로
export type mainCompanyFilter = "revenueDesc" | "revenueAsc"; 이렇게 매출액 높은순, 매출액 적은순만 대충 적어놨는데, 이거는 필터 추가하시는대로 제가 맞게 수정하겠습니다.
최종적으로 main에서 사용할 api 반환 데이터는 CompanyListResponse 타입에 맞게, 아래처럼 만들어주시면 좋을 것 같습니다.
백엔드에 제가 만들어둔 getApplicationList.ts 보시면 카테고리 불러오는거랑 지원자수 계산하는것도 있고 최종 response 반환하는 부분도 동일하니까  참고하시면 돼요.
{
  companies: [
  {
  id: string;
  idx: string;
  name: string;
  image?: string;
  content: string;
  category: { id: string; category: string }[];
  salesRevenue: string;
  employeeCnt: number;
  applicantCnt: number;
  createdAt: string;
  updatedAt: string;
  }
  page: number;
  totalPages: number;
}