### PR TITLE
feat/ main, my-applications 페이지 필터 기능 추가

### DIFF
--- a/app/main/core/companiesFetchHook.tsx
+++ b/app/main/core/companiesFetchHook.tsx
@@ -27,7 +27,7 @@ export const useCompanyListFetch = (
       setIsLoading(true);
       const startTime = Date.now();
 
-      console.log("쿼리 파라미터: ", params);
+      // console.log("쿼리 파라미터: ", params);
       const response: CompanyListResponse = await getCompanyListAPI(params);
       setData({
         companies: response.companies,

--- a/app/main/core/companyListAPI.ts
+++ b/app/main/core/companyListAPI.ts
@@ -17,7 +17,6 @@ export const getCompanyListAPI = async (
   //쿼리 기본값
   const { page = 1, search = "", filter = "revenueDesc" } = params;
 
-  //FIXME: 지금 엔드포인트는 세정님이 만드신 api로 연결되는데, 재완님한테 검색키워드랑 필터, 페이지 쿼리 받아서 카테고리도 추가 + 지원자수도 계산하고  totalpages, page까지 같이 반환해주는걸로 api짜달라고 하기
   try {
     const response: AxiosResponse<CompanyListResponse> = await instance.get(
       "/api/main/companies",

--- a/app/main/core/companyListAPI.ts
+++ b/app/main/core/companyListAPI.ts
@@ -24,7 +24,7 @@ export const getCompanyListAPI = async (
         params: { page, search, filter },
       }
     );
-    console.log("getCompanyListAPI: ", response.data);
+    // console.log("getCompanyListAPI: ", response.data);
     return response.data;
   } catch (err) {
     throw err;

--- a/app/main/core/companyListAPI.ts
+++ b/app/main/core/companyListAPI.ts
@@ -8,21 +8,21 @@ import {
 /** 전체 기업 조회
  * @param {Object} params - 쿼리 정보
  * @param {int} params.page - 페이지 번호
- * @param {int} params.keyword - 검색 키워드
+ * @param {int} params.search - 검색 키워드
  * @param {int} params.filter - 필터
  */
 export const getCompanyListAPI = async (
   params: Partial<CompanyListQuery> = {}
 ): Promise<CompanyListResponse> => {
   //쿼리 기본값
-  const { page = 1, keyword = "", filter = "revenueDesc" } = params;
+  const { page = 1, search = "", filter = "revenueDesc" } = params;
 
   //FIXME: 지금 엔드포인트는 세정님이 만드신 api로 연결되는데, 재완님한테 검색키워드랑 필터, 페이지 쿼리 받아서 카테고리도 추가 + 지원자수도 계산하고  totalpages, page까지 같이 반환해주는걸로 api짜달라고 하기
   try {
     const response: AxiosResponse<CompanyListResponse> = await instance.get(
-      "/api/companies",
+      "/api/main/companies",
       {
-        params: { page, keyword, filter },
+        params: { page, search, filter },
       }
     );
     console.log("getCompanyListAPI: ", response.data);

--- a/app/main/features/companyList/components/CompanyItems.tsx
+++ b/app/main/features/companyList/components/CompanyItems.tsx
@@ -55,7 +55,10 @@ export function CompanyItems({ ranking, itemData }: CompanyItemsProps) {
           className="text_M_14"
           content={itemData.name}
           color={colorChips.white}
-          customStyle={{ textAlign: "center" }}
+          customStyle={{
+            textAlign: "center",
+            overflow: "hidden",
+          }}
         />
       </Box>
       <Box

--- a/app/main/features/companyList/components/CompanyItems.tsx
+++ b/app/main/features/companyList/components/CompanyItems.tsx
@@ -15,6 +15,7 @@ import {
   labelDescBoxStyle,
   labelOrderBoxStyle,
 } from "@/global/styles/companyListStyles";
+import { useRouter } from "next/navigation";
 
 interface CompanyItemsProps {
   ranking: number;
@@ -23,9 +24,16 @@ interface CompanyItemsProps {
 
 export function CompanyItems({ ranking, itemData }: CompanyItemsProps) {
   const { imgSrc, handleImgErr } = useCompanyDefaultImg(itemData.image);
+  const router = useRouter();
+
+  const companyId = itemData.id;
+
+  const handleClick = () => {
+    router.push(`/company-detail/${companyId}`);
+  };
 
   return (
-    <Stack sx={companyItemBoxStyle}>
+    <Stack sx={companyItemBoxStyle} onClick={handleClick}>
       <Box sx={labelOrderBoxStyle}>
         <Typo
           className="text_R_14"

--- a/app/main/features/companyList/feature.tsx
+++ b/app/main/features/companyList/feature.tsx
@@ -8,6 +8,8 @@ interface CompanyListProps {
   page: number | undefined;
 }
 
+//TODO: 각 companyItems 로우 클릭했을 때, 해당 companyId로 라우팅되도록
+
 export default function CompanyList({ companies, page = 1 }: CompanyListProps) {
   return (
     <Stack sx={companyListWrapperStyle}>

--- a/app/main/features/listTitle/feature.tsx
+++ b/app/main/features/listTitle/feature.tsx
@@ -3,7 +3,7 @@ import { SearchInput } from "@/global/components/input/SearchInput";
 import { colorChips } from "@/global/styles/colorChips";
 import { Typo } from "@/global/styles/Typo";
 import { FilterOption, mainCompanyFilter } from "@/global/types/data-contracts";
-import { Box, SelectChangeEvent, Stack } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import React, { useState } from "react";
 
 interface ListTitleProps {
@@ -47,9 +47,7 @@ export default function ListTitle({
     ].includes(value);
   }
 
-  const handleFilterChange = (e: SelectChangeEvent) => {
-    const selectedValue = e.target.value;
-
+  const handleFilterChange = (selectedValue: string) => {
     if (isMainCompanyFilter(selectedValue)) {
       setSelectedFilter(selectedValue);
       onSelect(selectedValue);
@@ -114,5 +112,4 @@ const sortBoxStyle = {
   alignItems: "center",
   width: ["146px", "168px"],
   height: ["40px", "48px"],
-  border: `1px solid ${colorChips.white}`, //border는 컴포넌트 넣고 삭제
 };

--- a/app/main/features/listTitle/feature.tsx
+++ b/app/main/features/listTitle/feature.tsx
@@ -1,16 +1,29 @@
+import { CustomSelect } from "@/global/components/CustomSelect";
 import { SearchInput } from "@/global/components/input/SearchInput";
 import { colorChips } from "@/global/styles/colorChips";
 import { Typo } from "@/global/styles/Typo";
-import { Box, Stack } from "@mui/material";
-import React from "react";
+import { FilterOption, mainCompanyFilter } from "@/global/types/data-contracts";
+import { Box, SelectChangeEvent, Stack } from "@mui/material";
+import React, { useState } from "react";
 
 interface ListTitleProps {
-  onSearch: (keyword: string) => void;
+  onSearch: (search: string) => void;
+  onSelect: (filter: mainCompanyFilter) => void;
 }
+
+const mainFilterOptions: FilterOption[] = [
+  { value: "revenueDesc", name: "매출액 높은순" },
+  { value: "revenueAsc", name: "매출액 낮은순" },
+  { value: "employeeDesc", name: "사원 수 많은순" },
+  { value: "employeeAsc", name: "사원 수 적은순" },
+];
 
 export default function ListTitle({
   onSearch,
+  onSelect,
 }: ListTitleProps): React.ReactElement {
+  const [selectedFilter, setSelectedFilter] = useState<string>("revenueDesc");
+
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>): void => {
     const value = e.target.value.trim();
     onSearch(value);
@@ -22,6 +35,24 @@ export default function ListTitle({
     if (e.key === "Enter") {
       const value = target.value.trim();
       onSearch(value);
+    }
+  };
+
+  function isMainCompanyFilter(value: string): value is mainCompanyFilter {
+    return [
+      "revenueDesc",
+      "revenueAsc",
+      "employeeDesc",
+      "employeeAsc",
+    ].includes(value);
+  }
+
+  const handleFilterChange = (e: SelectChangeEvent) => {
+    const selectedValue = e.target.value;
+
+    if (isMainCompanyFilter(selectedValue)) {
+      setSelectedFilter(selectedValue);
+      onSelect(selectedValue);
     }
   };
 
@@ -42,10 +73,11 @@ export default function ListTitle({
           />
         </Box>
         <Box sx={sortBoxStyle}>
-          <Typo
-            className="text_SB_20"
-            content="정렬"
-            color={colorChips.white}
+          <CustomSelect
+            options={mainFilterOptions}
+            value={selectedFilter}
+            handleChange={handleFilterChange}
+            defaultValue="revenueDesc"
           />
         </Box>
       </Stack>

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -29,7 +29,7 @@ export default function Main() {
     setParams((prev) => ({ ...prev, ...newParams }));
   }, []);
 
-  console.log("params 업데이트 테스트: ", params);
+  // console.log("params 업데이트 테스트: ", params);
 
   //api호출
   const { companies, totalPages, isLoading } = useCompanyListFetch(params);

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -14,41 +14,6 @@ import {
   scrollWrapper,
 } from "@/global/styles/companyListStyles";
 
-//TODO: 백엔드 api 불러와서 목데이터랑 totalPages 지우기
-const totalPages = 5;
-
-const companies = [
-  {
-    id: "22",
-    idx: "22",
-    name: "코드잇",
-    image:
-      "https://s3-alpha-sig.figma.com/img/14ea/2072/7d797dc61be213072dfdfe95dc9d2494?Expires=1739145600&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=NDjzJ4~YCVsb5sToJq49pE63fuvnB6MksZU3tEKQhmRkJ3PZ6iOq-XL82aHpZ56F8TZwkzwjwjwGPt6Qe1yH~NEye~NRFF~o3yVNdG0Zg8oBkZAkmOM3oTVmoA5Xh8J-X3~6cTjYSLjNtP3ObTC7d-NwCaeQmkw12r5hH3rOmsVjk~~Crx6yMTqdQZRdSmaIW6e0pPek6U1kTdphUWYbfx2koA7DS02NtHR3oFBfeLqTl4du5gomP2XRk3-CYc8CwFO0VMk0p5f~CX478UzYf2Ogzsasj9~SZxFEt0pmlS3JsfFfrpsUdV-Xt94zKisHvRrkLbdw0r3nKGm5hrMsuA__",
-    content:
-      '코드잇은 온라인 코딩 교육 서비스를 운영하는 EdTech 스타트업입니다. 코딩 교육과 데이터 사이언스 교육에 대한 수요는 급격히 늘어나고 있지만, 아직까지 좋은 교육 서비스를 찾기란 쉽지 않습니다. 이를 해결하고자 코드잇은 모든 강의를 자체 제작하여 퀄리티 높은 콘텐츠를 제공하고, 동시에 코딩 교육에 최적화된 플랫폼을 개발하고 있습니다. 모든 강의를 마음껏 들을 수 있는 "코드잇 무제한 멤버십"을 제공하고 있으며, 지난 5년 동안 21만 명의 수강생과 평균 만족도 4.9점이라는 국내 교육 업계에서 보기 드문 성과를 달성하였습니다. 또한 콘텐츠와 기술력을 인정받아 2021년 10월 Series B 투자를 받아 누적 140억 원의 투자를 받았고, 현재 40여 명의 팀원이 같은 목표를 향해 나아가고 있습니다.',
-    category: [{ id: "wer", category: "에듀테크" }],
-    salesRevenue: "14000000000",
-    employeeCnt: 50,
-    applicantCnt: 12,
-    createdAt: "2025-02-14",
-    updatedAt: "2025-02-15",
-  },
-  {
-    id: "22",
-    idx: "22",
-    name: "뤼이드",
-    image: "/#fdsa",
-    content:
-      '뤼이드는 온라인 코딩 교육 서비스를 운영하는 EdTech 스타트업입니다. 코딩 교육과 데이터 사이언스 교육에 대한 수요는 급격히 늘어나고 있지만, 아직까지 좋은 교육 서비스를 찾기란 쉽지 않습니다. 이를 해결하고자 코드잇은 모든 강의를 자체 제작하여 퀄리티 높은 콘텐츠를 제공하고, 동시에 코딩 교육에 최적화된 플랫폼을 개발하고 있습니다. 모든 강의를 마음껏 들을 수 있는 "코드잇 무제한 멤버십"을 제공하고 있으며, 지난 5년 동안 21만 명의 수강생과 평균 만족도 4.9점이라는 국내 교육 업계에서 보기 드문 성과를 달성하였습니다. 또한 콘텐츠와 기술력을 인정받아 2021년 10월 Series B 투자를 받아 누적 140억 원의 투자를 받았고, 현재 40여 명의 팀원이 같은 목표를 향해 나아가고 있습니다.',
-    category: [{ id: "wer", category: "에듀테크" }],
-    salesRevenue: "350000000",
-    employeeCnt: 12,
-    applicantCnt: 6,
-    createdAt: "2025-02-14",
-    updatedAt: "2025-02-15",
-  },
-];
-
 export default function Main() {
   const [params, setParams] = useState<CompanyListQuery>({
     page: 1, //기본 1페이지
@@ -67,9 +32,9 @@ export default function Main() {
   console.log("params 업데이트 테스트: ", params);
 
   //api호출
-  // const { companies, totalPages, isLoading } = useCompanyListFetch(params);
+  const { companies, totalPages, isLoading } = useCompanyListFetch(params);
 
-  // const isShowSkeleton = isLoading || !companies.length;
+  const isShowSkeleton = isLoading || !companies.length;
 
   return (
     <Stack sx={listLayout}>
@@ -81,11 +46,11 @@ export default function Main() {
       <Box sx={scrollWrapper}>
         <Box sx={listWrapperStyle}>
           <Single.ListLabel />
-          {/* {isShowSkeleton ? (
+          {isShowSkeleton ? (
             <SkeletonCompanyList />
-          ) : ( */}
-          <Features.CompanyList companies={companies} page={params.page} />
-          {/* )} */}
+          ) : (
+            <Features.CompanyList companies={companies} page={params.page} />
+          )}
         </Box>
       </Box>
 

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -52,7 +52,7 @@ const companies = [
 export default function Main() {
   const [params, setParams] = useState<CompanyListQuery>({
     page: 1, //기본 1페이지
-    keyword: "",
+    search: "",
     filter: "revenueDesc", //기본 정렬 기준: 매출액 높은 순
   });
 
@@ -73,7 +73,10 @@ export default function Main() {
 
   return (
     <Stack sx={listLayout}>
-      <Features.ListTitle onSearch={(keyword) => updateParams({ keyword })} />
+      <Features.ListTitle
+        onSearch={(search) => updateParams({ search })}
+        onSelect={(filter) => updateParams({ filter })}
+      />
 
       <Box sx={scrollWrapper}>
         <Box sx={listWrapperStyle}>

--- a/app/my-applications/core/applicationListAPI.ts
+++ b/app/my-applications/core/applicationListAPI.ts
@@ -23,7 +23,7 @@ export const getApplicationListAPI = async (
         params: { page, filter },
       }
     );
-    console.log("getApplicationList: ", response.data);
+    // console.log("getApplicationList: ", response.data);
     return response.data;
   } catch (err) {
     throw err;

--- a/app/my-applications/core/applicationsFetchHook.tsx
+++ b/app/my-applications/core/applicationsFetchHook.tsx
@@ -27,7 +27,7 @@ export const useApplicationFetch = (
       setIsLoading(true);
       const startTime = Date.now();
 
-      console.log("쿼리 파라미터: ", params);
+      // console.log("쿼리 파라미터: ", params);
       const response: ApplicationListResponse = await getApplicationListAPI(
         params
       );

--- a/app/my-applications/features/companyList/components/CompanyItems.tsx
+++ b/app/my-applications/features/companyList/components/CompanyItems.tsx
@@ -14,6 +14,7 @@ import {
   companyDescTypoStyle,
   labelDataBoxStyle,
 } from "@/global/styles/companyListStyles";
+import { useRouter } from "next/navigation";
 
 interface CompanyItemsProps {
   order: number;
@@ -36,9 +37,16 @@ export function CompanyItems({ order, itemData }: CompanyItemsProps) {
     itemData.status === "ACCEPTED"
       ? colorChips.brand_orange
       : colorChips.gray_300;
+  const router = useRouter();
+
+  const companyId = itemData.id;
+
+  const handleClick = () => {
+    router.push(`/company-detail/${companyId}`);
+  };
 
   return (
-    <Stack sx={companyItemBoxStyle}>
+    <Stack sx={companyItemBoxStyle} onClick={handleClick}>
       <Box sx={labelOrderBoxStyle}>
         <Typo
           className="text_R_14"

--- a/app/my-applications/features/companyList/components/CompanyItems.tsx
+++ b/app/my-applications/features/companyList/components/CompanyItems.tsx
@@ -28,7 +28,7 @@ export function CompanyItems({ order, itemData }: CompanyItemsProps) {
   };
   const status =
     itemData.status === "PENDING"
-      ? "지원 완료"
+      ? "지원완료"
       : itemData.status === "ACCEPTED"
       ? "합격"
       : "불합격";

--- a/app/my-applications/features/listTitle/feature.tsx
+++ b/app/my-applications/features/listTitle/feature.tsx
@@ -1,14 +1,49 @@
+import { CustomSelect } from "@/global/components/CustomSelect";
 import { colorChips } from "@/global/styles/colorChips";
 import { Typo } from "@/global/styles/Typo";
-import { Box, Stack } from "@mui/material";
-import React from "react";
+import { applicationFilter, FilterOption } from "@/global/types/data-contracts";
+import { Box, SelectChangeEvent, Stack } from "@mui/material";
+import React, { useState } from "react";
 
-export default function ListTitle(): React.ReactElement {
+interface ListTitleProps {
+  onSelect: (filter: applicationFilter) => void;
+}
+
+const applicationFilterOptions: FilterOption[] = [
+  { value: "all", name: "전체" },
+  { value: "pending", name: "지원완료" },
+  { value: "accepted", name: "합격" },
+  { value: "rejected", name: "불합격" },
+];
+
+export default function ListTitle({
+  onSelect,
+}: ListTitleProps): React.ReactElement {
+  const [selectedFilter, setSelectedFilter] = useState<string>("all");
+
+  function isMainCompanyFilter(value: string): value is applicationFilter {
+    return ["all", "pending", "accepted", "rejected"].includes(value);
+  }
+
+  const handleFilterChange = (e: SelectChangeEvent) => {
+    const selectedValue = e.target.value;
+
+    if (isMainCompanyFilter(selectedValue)) {
+      setSelectedFilter(selectedValue);
+      onSelect(selectedValue);
+    }
+  };
+
   return (
     <Stack sx={listHeaderContainerStyle}>
       <Typo className="text_B_20" content="지원현황" color={colorChips.white} />
       <Box sx={sortBoxStyle}>
-        <Typo className="text_SB_20" content="정렬" color={colorChips.white} />
+        <CustomSelect
+          options={applicationFilterOptions}
+          value={selectedFilter}
+          handleChange={handleFilterChange}
+          defaultValue="all"
+        />
       </Box>
     </Stack>
   );

--- a/app/my-applications/features/listTitle/feature.tsx
+++ b/app/my-applications/features/listTitle/feature.tsx
@@ -2,7 +2,7 @@ import { CustomSelect } from "@/global/components/CustomSelect";
 import { colorChips } from "@/global/styles/colorChips";
 import { Typo } from "@/global/styles/Typo";
 import { applicationFilter, FilterOption } from "@/global/types/data-contracts";
-import { Box, SelectChangeEvent, Stack } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import React, { useState } from "react";
 
 interface ListTitleProps {
@@ -21,14 +21,12 @@ export default function ListTitle({
 }: ListTitleProps): React.ReactElement {
   const [selectedFilter, setSelectedFilter] = useState<string>("all");
 
-  function isMainCompanyFilter(value: string): value is applicationFilter {
+  function isApplicationFilter(value: string): value is applicationFilter {
     return ["all", "pending", "accepted", "rejected"].includes(value);
   }
 
-  const handleFilterChange = (e: SelectChangeEvent) => {
-    const selectedValue = e.target.value;
-
-    if (isMainCompanyFilter(selectedValue)) {
+  const handleFilterChange = (selectedValue: string) => {
+    if (isApplicationFilter(selectedValue)) {
       setSelectedFilter(selectedValue);
       onSelect(selectedValue);
     }
@@ -63,7 +61,6 @@ const listHeaderContainerStyle = {
 const sortBoxStyle = {
   display: "flex",
   alignItems: "center",
-  width: ["241px", "264px"],
+  width: ["150px", "170px"],
   height: ["40px", "48px"],
-  border: `1px solid ${colorChips.white}`, //border는 컴포넌트 넣고 삭제
 };

--- a/app/my-applications/page.tsx
+++ b/app/my-applications/page.tsx
@@ -37,7 +37,7 @@ export default function Page() {
 
   return (
     <Stack sx={listLayout}>
-      <Features.ListTitle />
+      <Features.ListTitle onSelect={(filter) => updateParams({ filter })} />
 
       <Box sx={scrollWrapper}>
         <Box sx={listWrapperStyle}>

--- a/app/my-applications/page.tsx
+++ b/app/my-applications/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-//TODO: 스켈레톤 뜨기 전에 잠깐 데이터가 보였다가 스켈레톤 보이는데, 이 부분 다시 잡아보자
-
 import { Box, Stack } from "@mui/material";
 import { Features } from "./features";
 import { Single } from "./single";

--- a/global/styles/companyListStyles.tsx
+++ b/global/styles/companyListStyles.tsx
@@ -9,16 +9,16 @@ export const listLayout = {
 };
 
 export const scrollWrapper = {
-  width: "100vw",
+  width: "100%",
   overflow: "hidden",
   position: "relative",
+  pl: { xs: "16px", sm: "0" },
+  pr: { xs: "16px", sm: "0" },
 };
 
 // 실제 스크롤되는 컨텐츠
 export const listWrapperStyle = {
   width: "100%",
-  pl: { xs: "16px", sm: "0" },
-  pr: { xs: "16px", sm: "0" },
   display: "flex",
   flexDirection: "column",
   alignItems: { xs: "flex-start", sm: "center" },

--- a/global/styles/companyListStyles.tsx
+++ b/global/styles/companyListStyles.tsx
@@ -77,6 +77,7 @@ export const companyListWrapperStyle = {
 };
 
 export const companyItemBoxStyle = {
+  cursor: "pointer",
   flexDirection: "row",
   height: "64px",
   borderBottom: `1px solid ${colorChips.gray_300}`,

--- a/global/types/data-contracts.ts
+++ b/global/types/data-contracts.ts
@@ -40,12 +40,17 @@ export interface CompanyDTO {
   updatedAt: string;
 }
 
-//FIXME: 백엔드 완성되면 맞게 수정하기
-export type mainCompanyFilter = "revenueDesc" | "revenueAsc";
+export type mainCompanyFilter =
+  | "revenueDesc"
+  | "revenueAsc"
+  | "employeeDesc"
+  | "employeeAsc";
+
+export type applicationFilter = "all" | "pending" | "accepted" | "rejected";
 
 export interface CompanyListQuery {
   page?: number;
-  keyword?: string;
+  search?: string;
   filter?: mainCompanyFilter;
 }
 
@@ -85,3 +90,5 @@ export interface BookmarkDTO {
   updatedAt: Date;
   deletedAt: Date | null;
 }
+
+export type FilterOption = { value: string; name: string };


### PR DESCRIPTION
- main, my-applications 페이지 필터 기능 구현 완료.
- 두 페이지 모두 리스트 아이템 클릭했을 때 상세페이지로 이동하도록 라우팅 추가하려고 헀는데, 지금 company-detail 페이지가 목업데이터로 구현되어있어서 잘 안돌아가는것같아요. 디테일 페이지 완성되면 추가 테스트 해보고 마무리할 예정입니다.
- api 요청 확인용 console.log는 전부 주석 처리 해두었습니다.